### PR TITLE
EDGE-1027 removed unnecessary participants from subscription object

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,21 +95,9 @@ const controller = new ApiController(client);
 const accountId = '01234';
 const sessionId = '56789';
 const participantId = '012';
-
-const participant1 = {
-    participantId: '456'
-};
-
-const participant2 = {
-  participantId: '789',
-  streamAliases: ['alias1', 'alias2']
-};
-
 const sessionIdArg = '012345';
-
 const subscriptions = {
-  sessionId: sessionIdArg,
-  participants: [participant1, participant2]
+  sessionId: sessionIdArg
 };
 
 controller.addParticipantToSession(accountId, sessionId, participantId, subscriptions);


### PR DESCRIPTION
The way the API works, if you only supply a session ID in the subscriptions argument, you will automatically be subscribed to all participants in a session. This makes supplying participant ids unnecessary in this case, which is why I have removed them.